### PR TITLE
Launchpad backend cleanup

### DIFF
--- a/Bicho/backends/lp.py
+++ b/Bicho/backends/lp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2012 GSyC/LibreSoft, Universidad Rey Juan Carlos
+# Copyright (C) 2012-2013 GSyC/LibreSoft, Universidad Rey Juan Carlos
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fixing copyright year, a misspelled comment, and a reference to Bugzilla when we mean Launchpad. Also, removing an unnecessary "from lazr.restfulclient.errors import HTTPError" since we never use HTTPError in `lp.py`.
