### PR TITLE
Fix windows install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(name="Bicho",
       url="http://metricsgrimoire.github.com/Bicho/",
       packages=['bicho', 'bicho.backends', 'bicho.db',
                   'bicho.post_processing'],
-      data_files=[('share/man/man1/', ['doc/bicho.1'])],
+      data_files=[('share/man/man1', ['doc/bicho.1'])],
       scripts=["bin/bicho"])


### PR DESCRIPTION
setup.py contained a trailing forward-slash for the man page
installation preventing install on Windows.